### PR TITLE
docs: 英語版READMEに日本語ドキュメントへのリンクを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # seimei-split
 
+[日本語ドキュメント](README.ja.md)
+
 Split Japanese full names into family name (sei) and given name (mei).
 
 ## Features


### PR DESCRIPTION
## Summary
- 英語版 README.md の先頭に日本語ドキュメント (README.ja.md) へのリンクを追加

## Test plan
- [ ] README.md のリンクが正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)